### PR TITLE
Setting tile dimensions and scale factors

### DIFF
--- a/rosa-iiif/rosa-iiif-image-core/src/main/java/rosa/iiif/image/core/FSIService.java
+++ b/rosa-iiif/rosa-iiif-image-core/src/main/java/rosa/iiif/image/core/FSIService.java
@@ -68,8 +68,8 @@ public class FSIService implements IIIFService {
         profile.setQualities(Quality.COLOR, Quality.GRAY);
         
         this.tile_info = new TileInfo();
-        tile_info.setWidth(max_image_size);
-        tile_info.setHeight(max_image_size);
+        tile_info.setWidth(256);
+        tile_info.setHeight(256);
         
         // TODO What should this be set to?
         tile_info.setScaleFactors(4);

--- a/rosa-iiif/rosa-iiif-image-core/src/main/java/rosa/iiif/image/core/FSIService.java
+++ b/rosa-iiif/rosa-iiif-image-core/src/main/java/rosa/iiif/image/core/FSIService.java
@@ -71,8 +71,8 @@ public class FSIService implements IIIFService {
         tile_info.setWidth(256);
         tile_info.setHeight(256);
         
-        // TODO What should this be set to?
-        tile_info.setScaleFactors(4);
+        // TODO: Determine these somehow
+        tile_info.setScaleFactors(1, 2, 4);
     }
 
     public String performURL(ImageRequest req) throws IIIFException {

--- a/rosa-iiif/rosa-iiif-image-endpoint/src/main/java/rosa/iiif/image/endpoint/IIIFServletModule.java
+++ b/rosa-iiif/rosa-iiif-image-endpoint/src/main/java/rosa/iiif/image/endpoint/IIIFServletModule.java
@@ -57,6 +57,6 @@ public class IIIFServletModule extends ServletModule {
 
     @Provides
     protected IIIFService provideImageService(@Named("fsi.url") String fsi_url) {
-        return new FSIService(fsi_url, 1000, 1000);
+        return new FSIService(fsi_url, -1, 1000);
     }
 }


### PR DESCRIPTION
Currently, the tile dimensions were being set to the maximum image dimensions the server was built with. So, if the server was built with -1 as the maximum height and width (in order to remove all restrictions on image sizes that could be served), the info.json response would contain -1 in the tile widths and heights. This resulted in OSD (and by extension, Mirador) not being able to display the images.

This pull request:
1. Sets the tile dimensions to 256 pixels each
2. Sets the scale factors to 1, 2, 4

Ideally these should either be somehow determined based on the server's capabilities OR picked up from a configuration file so that the package doesn't have to be rebuilt in order to tweak these values.