### PR TITLE
Change page mapping in the IdMapper to use the old ArchiveNameParser

### DIFF
--- a/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/AORIdMapper.java
+++ b/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/AORIdMapper.java
@@ -152,11 +152,7 @@ public class AORIdMapper {
     }
 
     private String getPageLabel(String book, String page) {
-        page = trimExt(page);
-        if (page.startsWith(book)) {
-            page = page.substring(book.length() + 1);
-        }
-        return page;
+        return nameParser.shortName(page);
     }
 
     private FileMap loadFileMap(String col, String parent) {


### PR DESCRIPTION
This fixes an issue encountered in the viewer with some internal references caused by bad target URIs