### PR TITLE
Add 'reader' tag to book metadata to be added as IIIF metadata

### DIFF
--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/MultilangMetadataSerializer.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/MultilangMetadataSerializer.java
@@ -134,6 +134,9 @@ public class MultilangMetadataSerializer implements Serializer<MultilangMetadata
             for (String author : data.getAuthors()) {
                 valueElement("author", author, bib, doc);
             }
+            for (String reader : data.getReaders()) {
+                valueElement("reader", reader, bib, doc);
+            }
             for (String detail : data.getDetails()) {
                 valueElement("detail", detail, bib, doc);
             }
@@ -231,6 +234,7 @@ public class MultilangMetadataSerializer implements Serializer<MultilangMetadata
             data.setType(text("type", el));
             data.setDetails(getTextValues("detail", el).toArray(new String[0]));
             data.setAuthors(getTextValues("author", el).toArray(new String[0]));
+            data.setReaders(getTextValues("reader", el).toArray(new String[0]));
             data.setNotes(getTextValues("note", el).toArray(new String[0]));
 
             map.put(lang, data);

--- a/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/meta/BiblioData.java
+++ b/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/meta/BiblioData.java
@@ -2,6 +2,7 @@ package rosa.archive.model.meta;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  *
@@ -21,6 +22,7 @@ public class BiblioData implements Serializable {
     private String[] details;
     private String[] authors;
     private String[] notes;
+    private String[] readers;
 
     private String language;
 
@@ -28,6 +30,7 @@ public class BiblioData implements Serializable {
         details = new String[0];
         authors = new String[0];
         notes = new String[0];
+        readers = new String[0];
     }
 
     public String getTitle() {
@@ -126,6 +129,46 @@ public class BiblioData implements Serializable {
         this.notes = notes;
     }
 
+    public String[] getReaders() {
+        return readers;
+    }
+
+    public void setReaders(String[] readers) {
+        this.readers = readers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BiblioData that = (BiblioData) o;
+        return Objects.equals(title, that.title) &&
+                Objects.equals(dateLabel, that.dateLabel) &&
+                Objects.equals(currentLocation, that.currentLocation) &&
+                Objects.equals(repository, that.repository) &&
+                Objects.equals(shelfmark, that.shelfmark) &&
+                Objects.equals(origin, that.origin) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(commonName, that.commonName) &&
+                Objects.equals(material, that.material) &&
+                Arrays.equals(details, that.details) &&
+                Arrays.equals(authors, that.authors) &&
+                Arrays.equals(notes, that.notes) &&
+                Arrays.equals(readers, that.readers) &&
+                Objects.equals(language, that.language);
+    }
+
+    @Override
+    public int hashCode() {
+
+        int result = Objects.hash(title, dateLabel, currentLocation, repository, shelfmark, origin, type, commonName, material, language);
+        result = 31 * result + Arrays.hashCode(details);
+        result = 31 * result + Arrays.hashCode(authors);
+        result = 31 * result + Arrays.hashCode(notes);
+        result = 31 * result + Arrays.hashCode(readers);
+        return result;
+    }
+
     @Override
     public String toString() {
         return "BiblioData{" +
@@ -141,51 +184,9 @@ public class BiblioData implements Serializable {
                 ", details=" + Arrays.toString(details) +
                 ", authors=" + Arrays.toString(authors) +
                 ", notes=" + Arrays.toString(notes) +
+                ", readers=" + Arrays.toString(readers) +
                 ", language='" + language + '\'' +
                 '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        BiblioData that = (BiblioData) o;
-
-        if (!Arrays.equals(authors, that.authors)) return false;
-        if (commonName != null ? !commonName.equals(that.commonName) : that.commonName != null) return false;
-        if (currentLocation != null ? !currentLocation.equals(that.currentLocation) : that.currentLocation != null)
-            return false;
-        if (dateLabel != null ? !dateLabel.equals(that.dateLabel) : that.dateLabel != null) return false;
-        if (!Arrays.equals(details, that.details)) return false;
-        if (language != null ? !language.equals(that.language) : that.language != null) return false;
-        if (material != null ? !material.equals(that.material) : that.material != null) return false;
-        if (!Arrays.equals(notes, that.notes)) return false;
-        if (origin != null ? !origin.equals(that.origin) : that.origin != null) return false;
-        if (repository != null ? !repository.equals(that.repository) : that.repository != null) return false;
-        if (shelfmark != null ? !shelfmark.equals(that.shelfmark) : that.shelfmark != null) return false;
-        if (title != null ? !title.equals(that.title) : that.title != null) return false;
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = title != null ? title.hashCode() : 0;
-        result = 31 * result + (dateLabel != null ? dateLabel.hashCode() : 0);
-        result = 31 * result + (currentLocation != null ? currentLocation.hashCode() : 0);
-        result = 31 * result + (repository != null ? repository.hashCode() : 0);
-        result = 31 * result + (shelfmark != null ? shelfmark.hashCode() : 0);
-        result = 31 * result + (origin != null ? origin.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (commonName != null ? commonName.hashCode() : 0);
-        result = 31 * result + (material != null ? material.hashCode() : 0);
-        result = 31 * result + (details != null ? Arrays.hashCode(details) : 0);
-        result = 31 * result + (authors != null ? Arrays.hashCode(authors) : 0);
-        result = 31 * result + (notes != null ? Arrays.hashCode(notes) : 0);
-        result = 31 * result + (language != null ? language.hashCode() : 0);
-        return result;
     }
 
     public String getLanguage() {

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/CollectionTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/CollectionTransformer.java
@@ -6,7 +6,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -32,9 +31,9 @@ import rosa.iiif.presentation.model.TextValue;
 import rosa.iiif.presentation.model.Within;
 
 public class CollectionTransformer extends BasePresentationTransformer {
-    public static final String TOP_COLLECTION_LABEL = "All JHU IIIF Collections";
-    public static final String TOP_COLLECTION_NAME = "top";
-    public static final String LANGUAGE_DEFAULT = "en";
+//    public static final String TOP_COLLECTION_LABEL = "All JHU IIIF Collections";
+//    public static final String TOP_COLLECTION_NAME = "top";
+    private static final String LANGUAGE_DEFAULT = "en";
     private static final int MAX_THUMBNAILS = 3;
 
     private SimpleStore store;
@@ -103,7 +102,7 @@ public class CollectionTransformer extends BasePresentationTransformer {
                 col.addService(new Service( JHSearchService.CONTEXT_URI, parentURI, IIIF_SEARCH_PROFILE, parentCol.getLabel()));
             } catch (IOException e) {}
         }
-        col.setWithin(parents.toArray(new Within[parents.size()]));
+        col.setWithin(parents.toArray(new Within[0]));
 
         return col;
     }
@@ -148,15 +147,27 @@ public class CollectionTransformer extends BasePresentationTransformer {
                 }
                 map.put("pageCount", new HtmlValue(String.valueOf(b.getImages().getImages().size()), LANGUAGE_DEFAULT));
 
-                ref.setMetadata(map);
-
                 if (b.getMultilangMetadata() != null && b.getMultilangMetadata().getBiblioDataMap() != null
                         && b.getMultilangMetadata().getBiblioDataMap().containsKey(LANGUAGE_DEFAULT)) {
                     String[] auths = b.getMultilangMetadata().getBiblioDataMap().get(LANGUAGE_DEFAULT).getAuthors();
                     if (auths != null && auths.length > 0) {
                         ref.addSortingTag("0" + auths[0]);
                     }
+                    String[] readers = b.getMultilangMetadata().getBiblioDataMap().get(LANGUAGE_DEFAULT).getReaders();
+                    if (readers != null && readers.length > 0) {
+                        StringBuilder sb = new StringBuilder();
+                        for (int i = 0; i < readers.length; i++) {
+                            if (i > 0) {
+                                sb.append(" ");
+                            }
+                            sb.append(readers[i]);
+                        }
+                        map.put("Reader", new HtmlValue(sb.toString(), LANGUAGE_DEFAULT));
+                    }
                 }
+
+                ref.setMetadata(map);
+
                 if (hasContent(bm.getCommonName())) {
                     ref.addSortingTag("1" + bm.getCommonName());
                 }

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/ManifestTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/ManifestTransformer.java
@@ -9,6 +9,7 @@ import com.google.inject.name.Named;
 import rosa.archive.model.Book;
 import rosa.archive.model.BookCollection;
 import rosa.archive.model.BookMetadata;
+import rosa.archive.model.meta.BiblioData;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.jhsearch.JHSearchService;
 import rosa.iiif.presentation.core.transform.Transformer;
@@ -174,6 +175,18 @@ public class ManifestTransformer extends BasePresentationTransformer implements 
             if (metadata.getMaterial() != null) {
                 map.put("material", new HtmlValue(metadata.getMaterial(), lang));
             }
+
+            if (book.getMultilangMetadata() != null && book.getMultilangMetadata().getBiblioDataMap().containsKey(lang)) {
+                BiblioData bd = book.getMultilangMetadata().getBiblioDataMap().get(lang);
+
+                if (bd.getReaders().length > 0) {
+                    map.put("reader", new HtmlValue(bd.getReaders()[0], lang));
+                }
+                if (bd.getAuthors().length > 0) {
+                    map.put("author", new HtmlValue(bd.getAuthors()[0], lang));
+                }
+            }
+
 
             // TODO book texts
         }


### PR DESCRIPTION
Add `<reader>` tag to the book metadata with value set to the "main reader(or annotator)" of the book. For AOR1 books, the reader = Gabriel Harvey, AOR2 books, reader = John Dee. This is added to each book's IIIF metadata. Must be associated with a UI change to display correct images for books.