### PR TITLE
Migrate tei metadata

### DIFF
--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/BookMetadataSerializer.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/BookMetadataSerializer.java
@@ -21,6 +21,8 @@ import rosa.archive.model.BookMetadata;
 import rosa.archive.model.BookText;
 
 /**
+ * Serialization format is a custom TEI profile.
+ * 
  * @see rosa.archive.model.BookMetadata
  */
 public class BookMetadataSerializer implements Serializer<BookMetadata> {

--- a/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/ArchiveTool.java
+++ b/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/ArchiveTool.java
@@ -242,7 +242,7 @@ public class ArchiveTool {
             String sheet_dir = cmdline.getOptionValue(Flag.SPREADSHEET_DIR.longName(), null);
             aorTranscriptionChecker.run(args[1], true, sheet_dir, report);
             break;
-        case SEPARATE_TEI_METADATA:
+        case MIGRATE_TEI_METADATA:
             TEIDescriptionConverter.run(cmdline, config, report);
             break;
         }
@@ -291,7 +291,7 @@ public class ArchiveTool {
                 String sheet_dir = cmdline.getOptionValue(Flag.SPREADSHEET_DIR.longName(), null);
                 aorTranscriptionChecker.run(args[1], false, sheet_dir, report);
                 break;
-            case SEPARATE_TEI_METADATA:
+            case MIGRATE_TEI_METADATA:
                 TEIDescriptionConverter.run(cmdline, config, report);
                 break;
             default:

--- a/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/TEIDescriptionConverter.java
+++ b/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/TEIDescriptionConverter.java
@@ -22,6 +22,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+/**
+ * Convert TEI descriptions to our custom xml book metadata description.
+ * The TEI descriptions are left untouched.
+ */
 public class TEIDescriptionConverter {
     private static final BookMetadataSerializer bookMetadataSerializer = new BookMetadataSerializer();
     private static final MultilangMetadataSerializer multilangMetadataSerializer = new MultilangMetadataSerializer();
@@ -143,12 +147,14 @@ public class TEIDescriptionConverter {
     }
 
     private static void writeOutput(MultilangMetadata mm, Path outputPath, PrintStream report) {
-        try (OutputStream out = Files.newOutputStream(outputPath)) {
-
-            multilangMetadataSerializer.write(mm, out);
-
-        } catch (IOException e) {
-            report.printf("[ERROR] Failed to write output file. [%s]", outputPath.toAbsolutePath());
+        if (Files.exists(outputPath)) {
+            report.printf("[WARNING] Skipped existing [%s]", outputPath.toAbsolutePath());
+        } else {
+            try (OutputStream out = Files.newOutputStream(outputPath)) {
+                multilangMetadataSerializer.write(mm, out);
+            } catch (IOException e) {
+                report.printf("[ERROR] Failed to write output file. [%s]", outputPath.toAbsolutePath());
+            }
         }
     }
 

--- a/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/config/Command.java
+++ b/rosa-archive/rosa-archive-tool/src/main/java/rosa/archive/tool/config/Command.java
@@ -16,7 +16,7 @@ public enum Command {
     RENAME_TRANSCRIPTIONS("rename-transcriptions"),
     GENERATE_TEI("generate-tei"),
     CHECK_AOR("check-aor"),
-    SEPARATE_TEI_METADATA("separate-tei-metadata");
+    MIGRATE_TEI_METADATA("migrate-tei-metadata");
 
     private String display;
 


### PR DESCRIPTION
Try running the command migrate-tei-metadata on pizancollection and rosecollection. It should not overwrite existing metadata files. After this succeeds, you should see BOOK_ID.description.xml files. The original TEI metadata is not modified.