### PR TITLE
Remove textid and id attributes from BookText.

### DIFF
--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/check/BookChecker.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/check/BookChecker.java
@@ -348,37 +348,37 @@ public class BookChecker extends AbstractArchiveChecker {
         } else {
             for (BookText text : metadata.getTexts()) {
                 if (StringUtils.isBlank(text.getFirstPage())) {
-                    warnings.add("Metadata text first page not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata text first page not set. [" + metadata.getId() + "]");
                 } else if (!text.getFirstPage().matches(PAGE_PATTERN) && metadata.getType().equalsIgnoreCase(MANUSCRIPT)) {
                     errors.add("Page has bad format. [" + metadata.getId() + ":" + text.getFirstPage() + "]");
                 }
                 if (StringUtils.isBlank(text.getLastPage())) {
-                    warnings.add("Metadata text last page not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata text last page not set. [" + metadata.getId() + "]");
                 } else if (!text.getLastPage().matches(PAGE_PATTERN) && metadata.getType().equalsIgnoreCase(MANUSCRIPT)) {
                     errors.add("Page has bad format. [" + metadata.getId() + ":" + text.getLastPage() + "]");
                 }
                 if (StringUtils.isBlank(text.getTitle())) {
-                    warnings.add("Metadata text title not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata text title not set. [" + metadata.getId() + "]");
                 }
                 if (text.getNumberOfIllustrations() == -1) {
-                    warnings.add("Metadata number of illustrations not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata number of illustrations not set. [" + metadata.getId() + "]");
                 } else if (text.getNumberOfIllustrations() > metadata.getNumberOfIllustrations()) {
                     errors.add("Number of illustrations in text [" + text.getNumberOfIllustrations()
                             + "] is greater than the number if illustrations in the manuscript ["
-                            + metadata.getNumberOfIllustrations() + "] {" + metadata.getId() + ":" + text.getId() + "}");
+                            + metadata.getNumberOfIllustrations() + "] {" + metadata.getId() + "}");
                 }
                 if (text.getNumberOfPages() == -1) {
-                    warnings.add("Metadata number of pages not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata number of pages not set. [" + metadata.getId() + "]");
                 } else if (text.getNumberOfPages() > metadata.getNumberOfPages()) {
                     errors.add("Number of pages in text [" + text.getNumberOfPages() + "] exceeds number " +
                             "of pages in the manuscript [" + metadata.getNumberOfPages() + "] {"
-                            + metadata.getId() + ":" + text.getId() + "}");
+                            + metadata.getId() + "}");
                 }
                 if (text.getColumnsPerPage() == -1) {
-                    warnings.add("Metadata columns per page not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata columns per page not set. [" + metadata.getId() + "]");
                 }
                 if (text.getLinesPerColumn() == -1) {
-                    warnings.add("Metadata lines per column not set. [" + metadata.getId() + ":" + text.getId() + "]");
+                    warnings.add("Metadata lines per column not set. [" + metadata.getId() + "]");
                 }
             }
         }
@@ -436,7 +436,7 @@ public class BookChecker extends AbstractArchiveChecker {
                 for (int j = 0; j < reference.getTexts().length; j++) {
                     BookText refText = reference.getTexts()[j];
                     BookText testText = test.getTexts()[j];
-                    String textLabel = " [" + refText.getTextId() + "/" + testText.getTextId() + "] ";
+                    String textLabel = " [" + j + "] ";
 
                     if (testText.getLinesPerColumn() != refText.getLinesPerColumn()) {
                         errors.add("Book text lines per column different" + textLabel

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/BookMetadataSerializer.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/BookMetadataSerializer.java
@@ -97,10 +97,8 @@ public class BookMetadataSerializer implements Serializer<BookMetadata> {
             Element text = doc.createElement("text");
             texts.appendChild(text);
 
-            text.setAttribute("id", t.getId());
             valueElement("language", t.getLanguage(), text, doc);
             valueElement("title", t.getTitle(), text, doc);
-            valueElement("textId", t.getTextId(), text, doc);
 
             Element pages = valueElement("pages", t.getNumberOfPages(), text, doc);
             pages.setAttribute("end", t.getLastPage());
@@ -187,8 +185,6 @@ public class BookMetadataSerializer implements Serializer<BookMetadata> {
         for (Element textEl : getElementsInList("text", texts)) {
             BookText text = new BookText();
 
-            text.setId(textEl.getAttribute("id"));
-            text.setTextId(text("textId", textEl));
             text.setColumnsPerPage(number("columnsPerPage", textEl));
             text.setLeavesPerGathering(number("leavesPerGathering", textEl));
             text.setLinesPerColumn(number("linesPerColumn", textEl));

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/DeprecatedBookMetadataSerializer.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/DeprecatedBookMetadataSerializer.java
@@ -46,7 +46,6 @@ public class DeprecatedBookMetadataSerializer implements Serializer<DeprecatedBo
     private static final String MetadataTextsColsPerPageTag = "columnsPerFolio";
     private static final String MetadataTextsLeavesPerGatheringTag = "leavesPerGathering";
     private static final String MetadataTextsNumPagesTag = "folios";
-    private static final String MetadataTextsIdTag = "textid";
     private static final String MetadataTextsTitleTag = "title";
     private static final String MetadataTextsLocusTag = "locus";
     private static final String MetadataTextsFirstPageTag = "from";
@@ -186,7 +185,6 @@ public class DeprecatedBookMetadataSerializer implements Serializer<DeprecatedBo
             msItem.appendChild(textTitle);
             textTitle.appendChild(doc.createTextNode(text.getTitle()));
 
-            msItem.appendChild(note(MetadataTextsIdTag, text.getId(), doc));
             msItem.appendChild(note(MetadataTextsNumPagesTag, String.valueOf(text.getNumberOfPages()), doc));
             msItem.appendChild(note(MetadataNumIllustrationsTag,
                     String.valueOf(text.getNumberOfIllustrations()), doc));
@@ -386,14 +384,11 @@ public class DeprecatedBookMetadataSerializer implements Serializer<DeprecatedBo
             Element el = (Element) nodes.item(i);
             BookText text = new BookText();
 
-//            text.setId(String.valueOf(i));
-            text.setId(getString(el, MetadataTextsIdTag));
             text.setLinesPerColumn(getInteger(el, MetadataTextsLinesPerColTag));
             text.setColumnsPerPage(getInteger(el, MetadataTextsColsPerPageTag));
             text.setLeavesPerGathering(getInteger(el, MetadataTextsLeavesPerGatheringTag));
             text.setNumberOfIllustrations(getInteger(el, MetadataNumIllustrationsTag));
             text.setNumberOfPages(getInteger(el, MetadataTextsNumPagesTag));
-//            text.setTextId(getString(el, MetadataTextsIdTag));
             text.setTitle(getString(el, MetadataTextsTitleTag));
 
             NodeList locii = el.getElementsByTagName(MetadataTextsLocusTag);

--- a/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/serialize/BookMetadataSerializerTest.java
+++ b/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/serialize/BookMetadataSerializerTest.java
@@ -36,20 +36,18 @@ public class BookMetadataSerializerTest extends BaseSerializerTest<BookMetadata>
             "        <endDate>1950</endDate>\n" +
             "    </dates>\n" +
             "    <texts>\n" +
-            "        <text id=\"1\">\n" +
+            "        <text>\n" +
             "            <language>fr</language>\n" +
             "            <title>title</title>\n" +
-            "            <textId>rose</textId>\n" +
             "            <pages end=\"100r\" start=\"1r\">100</pages>\n" +
             "            <illustrations>1</illustrations>\n" +
             "            <linesPerColumn>2</linesPerColumn>\n" +
             "            <columnsPerPage>3</columnsPerPage>\n" +
             "            <leavesPerGathering>4</leavesPerGathering>\n" +
             "        </text>\n" +
-            "        <text id=\"2\">\n" +
+            "        <text>\n" +
             "            <language>fr</language>\n" +
             "            <title>title</title>\n" +
-            "            <textId>not rose</textId>\n" +
             "            <pages end=\"300r\" start=\"100v\">200</pages>\n" +
             "            <illustrations>0</illustrations>\n" +
             "            <linesPerColumn>0</linesPerColumn>\n" +
@@ -144,7 +142,6 @@ public class BookMetadataSerializerTest extends BaseSerializerTest<BookMetadata>
         BookText text = metadata.getBookTexts().get(0);
         assertNotNull(text);
         assertEquals("title", text.getTitle());
-        assertEquals("rose", text.getTextId());
         assertEquals(100, text.getNumberOfPages());
         assertEquals("1r", text.getFirstPage());
         assertEquals("100r", text.getLastPage());
@@ -241,9 +238,7 @@ public class BookMetadataSerializerTest extends BaseSerializerTest<BookMetadata>
 //        metadata.setLicenseUrl("http://example.org/license");
 
         BookText t1 = new BookText();
-        t1.setId("1");
         t1.setTitle("title");
-        t1.setTextId("rose");
         t1.setFirstPage("1r");
         t1.setLastPage("100r");
         t1.setNumberOfPages(100);
@@ -255,9 +250,7 @@ public class BookMetadataSerializerTest extends BaseSerializerTest<BookMetadata>
         metadata.getBookTexts().add(t1);
 
         BookText t2 = new BookText();
-        t2.setId("2");
         t2.setTitle("title");
-        t2.setTextId("not rose");
         t2.setFirstPage("100v");
         t2.setLastPage("300r");
         t2.setNumberOfPages(200);

--- a/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/serialize/DeprecatedBookMetadataSerializerTest.java
+++ b/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/serialize/DeprecatedBookMetadataSerializerTest.java
@@ -70,7 +70,7 @@ public class DeprecatedBookMetadataSerializerTest extends BaseSerializerTest<Dep
         assertEquals("                        <locus from=\"Page 0\" to=\"Page 1\">Page 0-Page 1</locus>",
                     lines.get(28));
         assertEquals("                        <note type=\"linesPerColumn\">45</note>",
-                    lines.get(53));
+                    lines.get(50));
     }
 
     @Override
@@ -102,7 +102,6 @@ public class DeprecatedBookMetadataSerializerTest extends BaseSerializerTest<Dep
         List<BookText> bookTextList = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             BookText text = new BookText();
-            text.setId("ID" + i);
             text.setFirstPage("Page " + i);
             text.setLastPage("Page " + (i+1));
             text.setColumnsPerPage(2);

--- a/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/BookText.java
+++ b/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/BookText.java
@@ -15,8 +15,6 @@ public final class BookText implements Serializable {
     private int leavesPerGathering;
     private int numberOfIllustrations;
     private int numberOfPages;
-    private String id;
-    private String textId;
     private String title;
     private String firstPage;
     private String lastPage;
@@ -76,14 +74,6 @@ public final class BookText implements Serializable {
         this.numberOfPages = numberOfPages;
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
     }
@@ -107,15 +97,7 @@ public final class BookText implements Serializable {
     public void setLastPage(String lastPage) {
         this.lastPage = lastPage;
     }
-
-    public String getTextId() {
-        return textId;
-    }
-
-    public void setTextId(String textId) {
-        this.textId = textId;
-    }
-
+    
     public String getLanguage() {
         return language;
     }
@@ -144,8 +126,6 @@ public final class BookText implements Serializable {
         if (leavesPerGathering != text.leavesPerGathering) return false;
         if (numberOfIllustrations != text.numberOfIllustrations) return false;
         if (numberOfPages != text.numberOfPages) return false;
-        if (id != null ? !id.equals(text.id) : text.id != null) return false;
-        if (textId != null ? !textId.equals(text.textId) : text.textId != null) return false;
         if (title != null ? !title.equals(text.title) : text.title != null) return false;
         if (firstPage != null ? !firstPage.equals(text.firstPage) : text.firstPage != null) return false;
         if (lastPage != null ? !lastPage.equals(text.lastPage) : text.lastPage != null) return false;
@@ -161,8 +141,6 @@ public final class BookText implements Serializable {
         result = 31 * result + leavesPerGathering;
         result = 31 * result + numberOfIllustrations;
         result = 31 * result + numberOfPages;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (textId != null ? textId.hashCode() : 0);
         result = 31 * result + (title != null ? title.hashCode() : 0);
         result = 31 * result + (firstPage != null ? firstPage.hashCode() : 0);
         result = 31 * result + (lastPage != null ? lastPage.hashCode() : 0);
@@ -179,8 +157,6 @@ public final class BookText implements Serializable {
                 ", leavesPerGathering=" + leavesPerGathering +
                 ", numberOfIllustrations=" + numberOfIllustrations +
                 ", numberOfPages=" + numberOfPages +
-                ", id='" + id + '\'' +
-                ", textId='" + textId + '\'' +
                 ", title='" + title + '\'' +
                 ", firstPage='" + firstPage + '\'' +
                 ", lastPage='" + lastPage + '\'' +

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/RangeTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/RangeTransformer.java
@@ -108,14 +108,18 @@ public class RangeTransformer extends BasePresentationTransformer implements Tra
 
         List<String> ranges = new ArrayList<>();
 
+        int text_count = 0;
         for (BookText text : metadata.getBookTexts()) {
+            text_count++;
+            String text_id = String.valueOf(text_count);
+            
             if (range_id.equals(TOP_RANGE_ID)) {
                 // If TOP range, collect all BookText text_id's for sub-ranges
                 result.setViewingHint(ViewingHint.TOP);
                 result.setLabel("Text Type", lang_code);
 
-                ranges.add(constructRangeURI(col, book, TEXT_RANGE_TYPE, text.getTextId()));
-            } else if (text.getTextId().equals(range_id)) {
+                ranges.add(constructRangeURI(col, book, TEXT_RANGE_TYPE, text_id));
+            } else if (text_id.equals(range_id)) {
                 // If specific range, return canvases for specific BookText text_id
                 result.setLabel("Text Type: " + range_id, lang_code);
 


### PR DESCRIPTION
Remove textid and id from BookText which seem uneeded. They are only used in a trivial way by RangeTransformer which is not called in any case.

#342 