### PR TITLE
Serve data

### DIFF
--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/PresentationUris.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/PresentationUris.java
@@ -3,6 +3,7 @@ package rosa.iiif.presentation.core;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
+import rosa.archive.model.Book;
 import rosa.iiif.image.core.IIIFRequestFormatter;
 import rosa.iiif.presentation.core.jhsearch.JHSearchService;
 import rosa.iiif.presentation.model.PresentationRequest;
@@ -24,10 +25,13 @@ import rosa.search.model.SearchOptions;
 public class PresentationUris {
     private final IIIFPresentationRequestFormatter presFormatter;
     private final IIIFRequestFormatter imageFormatter;
+    private final StaticResourceRequestFormatter staticFormatter;
 
-    public PresentationUris(IIIFPresentationRequestFormatter presFormatter, IIIFRequestFormatter imageFormatter) {
+    public PresentationUris(IIIFPresentationRequestFormatter presFormatter, IIIFRequestFormatter imageFormatter,
+                            StaticResourceRequestFormatter staticFormatter) {
         this.presFormatter = presFormatter;
         this.imageFormatter = imageFormatter;
+        this.staticFormatter = staticFormatter;
     }
 
     public String getCollectionURI(String collection) {
@@ -103,5 +107,9 @@ public class PresentationUris {
         }
 
         return url.toString();
+    }
+
+    public String getStaticResourceUri(String collection, String book, String target) {
+        return staticFormatter.format(collection, book, target);
     }
 }

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/StaticResourceRequestFormatter.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/StaticResourceRequestFormatter.java
@@ -1,0 +1,53 @@
+package rosa.iiif.presentation.core;
+
+import com.google.inject.Inject;
+import rosa.iiif.image.core.UriUtil;
+
+public class StaticResourceRequestFormatter {
+    private final String scheme;
+    private final String host;
+    private final String prefix;
+    private final int port;
+
+    /**
+     * @param scheme
+     *            http or https
+     * @param host the host
+     * @param port
+     *            -1 for default port
+     * @param prefix
+     *            must be encoded, start with '/', and not end with '/'.
+     */
+    @Inject
+    public StaticResourceRequestFormatter(String scheme, String host, String prefix, int port) {
+        this.scheme = scheme;
+        this.host = host;
+        this.prefix = prefix;
+        this.port = port;
+    }
+
+    private String base() {
+        return scheme + "://" + host + (port == -1 || (scheme.equals("http") && port == 80) || (scheme.equals("https") && port == 443) ? "" : ":" + port) + prefix + "/";
+    }
+
+    /**
+     * Get a URI that points to a static resource that has been exposed.
+     *
+     * @param collection name of collection
+     * @param book name of parent book (can be NULL if target is in a Collection)
+     * @param target name of target file
+     * @return URI to the target
+     */
+    public String format(String collection, String book, String target) {
+        StringBuilder result = new StringBuilder(base());
+
+        result.append(UriUtil.encodePathSegment(collection)).append('/');
+        if (book != null && !book.isEmpty()) {
+            result.append(UriUtil.encodePathSegment(book)).append('/');
+        }
+        result.append(UriUtil.encodePathSegment(target));
+
+        return result.toString();
+    }
+
+}

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/tool/ToolModule.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/tool/ToolModule.java
@@ -12,6 +12,7 @@ import rosa.archive.core.check.BookChecker;
 import rosa.archive.core.check.BookCollectionChecker;
 import rosa.archive.core.serialize.SerializerSet;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 
 /**
  * Guice module for build tools.
@@ -42,5 +43,13 @@ public class ToolModule extends AbstractModule {
                                                                            @Named("iiif.image.prefix") String prefix,
                                                                            @Named("iiif.image.port") int port) {
         return new rosa.iiif.image.core.IIIFRequestFormatter(scheme, host, port, prefix);
+    }
+
+    @Provides
+    StaticResourceRequestFormatter provideStaticResourceRequestFormatter(@Named("iiif.pres.scheme") String scheme,
+                                                                         @Named("iiif.pres.host") String host,
+                                                                         @Named("iiif.pres.prefix") String prefix,
+                                                                         @Named("iiif.pres.port") int port) {
+        return new StaticResourceRequestFormatter(scheme, host, prefix, port);
     }
 }

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/tool/WebAppResourceTool.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/tool/WebAppResourceTool.java
@@ -13,6 +13,7 @@ import rosa.archive.core.Store;
 import rosa.iiif.image.core.IIIFRequestFormatter;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.core.jhsearch.LuceneJHSearchService;
 import rosa.search.core.SearchService;
 
@@ -28,6 +29,7 @@ public class WebAppResourceTool {
         Store store = injector.getInstance(Store.class);
         IIIFPresentationRequestFormatter reqFormatter = injector.getInstance(IIIFPresentationRequestFormatter.class);
         IIIFRequestFormatter imageFormatter = injector.getInstance(IIIFRequestFormatter.class);
+        StaticResourceRequestFormatter staticFormatter = injector.getInstance(StaticResourceRequestFormatter.class);
         
         if (args.length != 1) {
             System.err.println("Usage: <tool> <web_app_path>");
@@ -47,7 +49,8 @@ public class WebAppResourceTool {
 
         System.out.println("## Indexing archive to " + archive_index_path);
 
-        SearchService service = new LuceneJHSearchService(archive_index_path, new PresentationUris(reqFormatter, imageFormatter));
+        SearchService service = new LuceneJHSearchService(archive_index_path, new PresentationUris(reqFormatter,
+                imageFormatter, staticFormatter));
 
         for (String col: store.listBookCollections()) {
                 service.update(store, col);

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/ManifestTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/ManifestTransformer.java
@@ -106,6 +106,12 @@ public class ManifestTransformer implements TransformerConstants {
                 collection.getLabel()
         ));
 
+        if (book.getBookDescription("en") != null) {
+            manifest.setRelatedUri(pres_uris.getStaticResourceUri(collection.getId(), book.getId(),
+                    book.getBookDescription("en").getId()));
+            manifest.setRelatedFormat("application/xml");
+        }
+
         return manifest;
     }
 
@@ -122,63 +128,53 @@ public class ManifestTransformer implements TransformerConstants {
             BookMetadata md = book.getBookMetadata();
             BiblioData bd = book.getBiblioData(lang);
 
-            map.put("currentLocation", new HtmlValue(bd.getCurrentLocation(), lang));
-            map.put("repository", new HtmlValue(bd.getRepository(), lang));
-            map.put("shelfmark", new HtmlValue(bd.getShelfmark(), lang));
-            map.put("origin", new HtmlValue(bd.getOrigin(), lang));
+            putMetadata(KEY_CURRENT_LOC, bd.getCurrentLocation(), lang, map);
+            putMetadata(KEY_REPO, bd.getRepository(), lang, map);
+            putMetadata(KEY_SHELFMARK, bd.getShelfmark(), lang, map);
+            putMetadata(KEY_ORIGIN, bd.getOrigin(), lang, map);
 
-            if (md.getWidth() != -1) {
-                map.put("width", new HtmlValue(md.getWidth() + "", lang));
-            }
-            if (md.getHeight() != -1) {
-                map.put("height", new HtmlValue(md.getHeight() + "", lang));
-            }
-            if (md.getYearStart() != -1) {
-                map.put("yearStart", new HtmlValue(md.getYearStart() + "", lang));
-            }
-            if (md.getYearEnd() != -1) {
-                map.put("yearEnd", new HtmlValue(md.getYearEnd() + "", lang));
-            }
-            if (md.getNumberOfPages() != -1) {
-                map.put("numberOfPages", new HtmlValue(md.getNumberOfPages() + "", lang));
-            }
-            if (md.getNumberOfIllustrations() != -1) {
-                map.put("numberOfIllustrations", new HtmlValue(md.getNumberOfIllustrations() + "", lang));
-            }
-            if (bd.getTitle() != null) {
-                map.put("title", new HtmlValue(bd.getTitle(), lang));
-            }
-            if (bd.getDateLabel() != null) {
-                map.put("date", new HtmlValue(bd.getDateLabel(), lang));
-            }
-            if (md.getDimensionsString() != null && !md.getDimensionsString().replaceAll("\\s+", "").equals("-1x-1")) {
-                map.put("dimensions", new HtmlValue(md.getDimensionsString(), lang));
-            }
-            if (md.getDimensionUnits() != null) {
-                map.put("dimensionUnits", new HtmlValue(md.getDimensionUnits(), lang));
-            }
-            if (bd.getType() != null) {
-                map.put("type", new HtmlValue(bd.getType(), lang));
-            }
-            if (bd.getCommonName() != null) {
-                map.put("commonName", new HtmlValue(bd.getCommonName(), lang));
-            }
-            if (bd.getMaterial() != null) {
-                map.put("material", new HtmlValue(bd.getMaterial(), lang));
+            putMetadata(KEY_WIDTH, md.getWidth(), lang, map);
+            putMetadata(KEY_HEIGHT, md.getHeight(), lang, map);
+            putMetadata(KEY_YEAR_START, md.getYearStart(), lang, map);
+            putMetadata(KEY_YEAR_END, md.getYearEnd(), lang, map);
+            putMetadata(KEY_NUM_PAGES, md.getNumberOfPages(), lang, map);
+            putMetadata(KEY_NUM_ILLS, md.getNumberOfIllustrations(), lang, map);
+            putMetadata(KEY_TITLE, bd.getTitle(), lang, map);
+            putMetadata(KEY_DATE, bd.getDateLabel(), lang, map);
+
+            if (md.getDimensionsString() != null
+                    && !md.getDimensionsString().replaceAll("\\s+", "").equals("-1x-1")) {
+                putMetadata(KEY_DIMS, md.getDimensionsString(), lang, map);
             }
 
-            if (bd.getReaders().length > 0) {
-                map.put("reader", new HtmlValue(bd.getReaders()[0], lang));
-            }
-            if (bd.getAuthors().length > 0) {
-                map.put("author", new HtmlValue(bd.getAuthors()[0], lang));
-            }
-            
-
+            putMetadata(KEY_DIM_UNITS, md.getDimensionUnits(), lang, map);
+            putMetadata(KEY_TYPE, bd.getType(), lang, map);
+            putMetadata(KEY_COMMON_NAME, bd.getCommonName(), lang, map);
+            putMetadata(KEY_MATERIAL, bd.getMaterial(), lang, map);
+            putMetadata(KEY_READER, bd.getReaders(), lang, map);
+            putMetadata(KEY_AUTHOR, bd.getAuthors(), lang, map);
 
             // TODO book texts
         }
 
         return map;
+    }
+
+    private void putMetadata(String key, int value, String lang, Map<String, HtmlValue> map) {
+        if (value != -1) {
+            putMetadata(key, String.valueOf(value), lang, map);
+        }
+    }
+
+    private void putMetadata(String key, String[] value, String lang, Map<String, HtmlValue> map) {
+        if (value != null && value.length > 0) {
+            putMetadata(key, String.join(", ", value), lang, map);
+        }
+    }
+
+    private void putMetadata(String key, String value, String lang, Map<String, HtmlValue> map) {
+        if (value != null && !value.isEmpty()) {
+            map.put(key, new HtmlValue(value, lang));
+        }
     }
 }

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/TransformerConstants.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/TransformerConstants.java
@@ -3,15 +3,35 @@ package rosa.iiif.presentation.core.transform.impl;
 import rosa.iiif.presentation.model.IIIFNames;
 
 public interface TransformerConstants extends IIIFNames {
-    static final String IMAGE_RANGE_MISC_ID = "misc";
-    static final String IMAGE_RANGE_BODYMATTER_ID = "bodymatter";
-    static final String IMAGE_RANGE_BINDING_ID = "binding";
-    static final String IMAGE_RANGE_ENDMATTER_ID = "endmatter";
-    static final String IMAGE_RANGE_FRONTMATTER_ID = "frontmatter";
-    static final String DEFAULT_SEQUENCE_LABEL = "reading-order";
-    static final String PAGE_REGEX = "\\d{1,3}(r|v|R|V)";
-    static final String TOP_RANGE_ID = "top";
-    static final String ILLUSTRATION_RANGE_TYPE = "illus";
-    static final String IMAGE_RANGE_TYPE = "image";
-    static final String TEXT_RANGE_TYPE = "text";
+    String IMAGE_RANGE_MISC_ID = "misc";
+    String IMAGE_RANGE_BODYMATTER_ID = "bodymatter";
+    String IMAGE_RANGE_BINDING_ID = "binding";
+    String IMAGE_RANGE_ENDMATTER_ID = "endmatter";
+    String IMAGE_RANGE_FRONTMATTER_ID = "frontmatter";
+    String DEFAULT_SEQUENCE_LABEL = "reading-order";
+    String PAGE_REGEX = "\\d{1,3}(r|v|R|V)";
+    String TOP_RANGE_ID = "top";
+    String ILLUSTRATION_RANGE_TYPE = "illus";
+    String IMAGE_RANGE_TYPE = "image";
+    String TEXT_RANGE_TYPE = "text";
+
+    String KEY_CURRENT_LOC = "currentLocation";
+    String KEY_REPO = "repository";
+    String KEY_SHELFMARK = "shelfmark";
+    String KEY_ORIGIN = "origin";
+    String KEY_WIDTH = "width";
+    String KEY_HEIGHT = "height";
+    String KEY_YEAR_START = "yearStart";
+    String KEY_YEAR_END = "yearEnd";
+    String KEY_NUM_PAGES = "numberOfPages";
+    String KEY_NUM_ILLS = "numberOfIllustrations";
+    String KEY_TITLE = "title";
+    String KEY_DATE = "date";
+    String KEY_DIMS = "dimensions";
+    String KEY_DIM_UNITS = "dimensionUnits";
+    String KEY_TYPE = "type";
+    String KEY_COMMON_NAME = "commonName";
+    String KEY_MATERIAL = "material";
+    String KEY_READER = "reader";
+    String KEY_AUTHOR = "author";
 }

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/ArchiveIIIFPresentationServiceTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/ArchiveIIIFPresentationServiceTest.java
@@ -39,10 +39,11 @@ public class ArchiveIIIFPresentationServiceTest extends BaseSearchTest {
 
         rosa.iiif.image.core.IIIFRequestFormatter imageFormatter = new rosa.iiif.image.core.IIIFRequestFormatter(
                 scheme, host, port, image_prefix);
+        StaticResourceRequestFormatter staticFormatter = new StaticResourceRequestFormatter(scheme, host, pres_prefix, port);
         ArchiveNameParser nameParser = new ArchiveNameParser();
         
         IIIFPresentationCache cache = new IIIFPresentationCache(store, 10);
-        PresentationUris pres_uris = new PresentationUris(requestFormatter, imageFormatter);
+        PresentationUris pres_uris = new PresentationUris(requestFormatter, imageFormatter, staticFormatter);
 
         PresentationTransformer transformer = new PresentationTransformerImpl(cache, pres_uris, nameParser);
 

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/StaticResourceRequestFormatterTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/StaticResourceRequestFormatterTest.java
@@ -1,0 +1,36 @@
+package rosa.iiif.presentation.core;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StaticResourceRequestFormatterTest {
+    private static final String EXPECTED_URL_START = "scheme://host/prefix/";
+    private StaticResourceRequestFormatter formatter;
+
+    @Before
+    public void setup() {
+        this.formatter = new StaticResourceRequestFormatter(
+                "scheme",
+                "host",
+                "/prefix",
+                -1
+        );
+    }
+
+    @Test
+    public void uriForCollectionCsvTest() {
+        String expected = EXPECTED_URL_START +  "rose/character_names.csv";
+        String result = formatter.format("rose", null, "character_names.csv");
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void uriForBookDescriptionTest() {
+        String expected = EXPECTED_URL_START + "rose/Walters143/Walters143.description_en.xml";
+        String result = formatter.format("rose", "Walters143", "Walters143.description_en.xml");
+        assertEquals(expected, result);
+    }
+
+}

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/html/MarginaliaHtmlAdapterTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/html/MarginaliaHtmlAdapterTest.java
@@ -8,6 +8,7 @@ import rosa.archive.model.aor.InternalReference;
 import rosa.archive.model.aor.ReferenceTarget;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,8 +30,14 @@ public class MarginaliaHtmlAdapterTest {
                 "",
                 -1
         );
+        StaticResourceRequestFormatter staticFormatter = new StaticResourceRequestFormatter(
+                "https",
+                "example.com",
+                "",
+                -1
+        );
 
-        adapter = new MarginaliaHtmlAdapter(new PresentationUris(requestFormatter, null));
+        adapter = new MarginaliaHtmlAdapter(new PresentationUris(requestFormatter, null, staticFormatter));
 
         fakeCollection = new BookCollection();
 

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/jhsearch/LuceneJHSearchServiceTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/jhsearch/LuceneJHSearchServiceTest.java
@@ -30,6 +30,7 @@ import rosa.archive.model.BookCollection;
 import rosa.iiif.image.core.IIIFRequestFormatter;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.model.IIIFNames;
 import rosa.iiif.presentation.model.PresentationRequest;
 import rosa.iiif.presentation.model.PresentationRequestType;
@@ -58,8 +59,9 @@ public class LuceneJHSearchServiceTest extends BaseSearchTest {
 
         IIIFPresentationRequestFormatter presFormatter = new IIIFPresentationRequestFormatter(scheme, host, pres_prefix, port);
         IIIFRequestFormatter imageFormatter = new IIIFRequestFormatter(scheme, host, port, image_prefix);
+        StaticResourceRequestFormatter staticFormatter = new StaticResourceRequestFormatter(scheme, host, pres_prefix, port);
         
-        service = new LuceneJHSearchService(tmpfolder.newFolder().toPath(), new PresentationUris(presFormatter, imageFormatter));
+        service = new LuceneJHSearchService(tmpfolder.newFolder().toPath(), new PresentationUris(presFormatter, imageFormatter, staticFormatter));
         service.update(store, VALID_COLLECTION);
         
         assertTrue(service.has_content());

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/transform/PresentationTransformerTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/transform/PresentationTransformerTest.java
@@ -18,6 +18,7 @@ import rosa.archive.core.BaseArchiveTest;
 import rosa.iiif.presentation.core.IIIFPresentationCache;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.core.transform.impl.PresentationTransformerImpl;
 import rosa.iiif.presentation.model.AnnotationList;
 import rosa.iiif.presentation.model.Canvas;
@@ -52,8 +53,9 @@ public class PresentationTransformerTest extends BaseArchiveTest {
         rosa.iiif.image.core.IIIFRequestFormatter imageFormatter =
                 new rosa.iiif.image.core.IIIFRequestFormatter(ENDPOINT_SCHEME, ENDPOINT_HOST, ENDPOINT_PORT, ENDPOINT_PREFIX);
         ArchiveNameParser nameParser = new ArchiveNameParser();
+        StaticResourceRequestFormatter staticFormatter = new StaticResourceRequestFormatter(ENDPOINT_SCHEME, ENDPOINT_HOST, ENDPOINT_PREFIX, ENDPOINT_PORT);
         IIIFPresentationCache cache = new IIIFPresentationCache(store, 1000);
-        PresentationUris pres_uris = new PresentationUris(presFormatter, imageFormatter);
+        PresentationUris pres_uris = new PresentationUris(presFormatter, imageFormatter, staticFormatter);
         
         presentationTransformer = new PresentationTransformerImpl(cache, pres_uris, nameParser);
     }
@@ -131,6 +133,10 @@ public class PresentationTransformerTest extends BaseArchiveTest {
         assertNotNull("", manifest.getOtherSequences());
         assertTrue("Unexpected other sequences found.", manifest.getOtherSequences().isEmpty());
         checkSequence(manifest.getDefaultSequence());
+
+        String expectedDescriptionUri = ENDPOINT_SCHEME + "://" + ENDPOINT_HOST + ENDPOINT_PREFIX +
+                "/valid/LudwigXV7/LudwigXV7.description_en.xml";
+        assertEquals(expectedDescriptionUri, manifest.getRelatedUri());
     }
 
     /**

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/transform/impl/AnnotationTransformerTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/transform/impl/AnnotationTransformerTest.java
@@ -13,6 +13,7 @@ import rosa.iiif.image.core.IIIFRequestFormatter;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.PresentationTestUtils;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.model.annotation.Annotation;
 
 import java.io.ByteArrayInputStream;
@@ -38,7 +39,8 @@ public class AnnotationTransformerTest extends BaseArchiveTest {
         IIIFPresentationRequestFormatter formatter =
                 new IIIFPresentationRequestFormatter("SCHEME", "HOST", "PREFIX", 80);
         IIIFRequestFormatter imageFormatter = new IIIFRequestFormatter("http", "localhost", 8080, "/image");
-        PresentationUris pres_uris = new PresentationUris(formatter, imageFormatter);
+        StaticResourceRequestFormatter staticFormatter = new StaticResourceRequestFormatter("http", "localhost", "/data", 80);
+        PresentationUris pres_uris = new PresentationUris(formatter, imageFormatter, staticFormatter);
         
         transformer = new AnnotationTransformer(pres_uris, new ArchiveNameParser(), PresentationTestUtils.htmlAdapterSet(pres_uris));
 

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/pom.xml
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/pom.xml
@@ -81,7 +81,23 @@
                                 <systemProperty>
                                     <key>iiif.image.port</key>
                                     <value>${iiif.image.port}</value>
-                                </systemProperty>                                
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>static.scheme</key>
+                                    <value>${iiif.pres.scheme}</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>static.host</key>
+                                    <value>${iiif.pres.host}</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>static.prefix</key>
+                                    <value>${iiif.pres.prefix}/data</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>static.port</key>
+                                    <value>${iiif.pres.port}</value>
+                                </systemProperty>
                             </systemProperties>
                         </configuration>
                         <goals>

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/AbstractStaticResourceServlet.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/AbstractStaticResourceServlet.java
@@ -1,0 +1,141 @@
+package rosa.iiif.presentation.endpoint;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet for static resources taken from https://stackoverflow.com/questions/132052/servlet-for-serving-static-content/29991447
+ */
+public abstract class AbstractStaticResourceServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private static final long ONE_SECOND_IN_MILLIS = TimeUnit.SECONDS.toMillis(1);
+    private static final String ETAG_HEADER = "W/\"%s-%s\"";
+    private static final String CONTENT_DISPOSITION_HEADER = "inline;filename=\"%1$s\"; filename*=UTF-8''%1$s";
+
+    public static final long DEFAULT_EXPIRE_TIME_IN_MILLIS = TimeUnit.DAYS.toMillis(30);
+    public static final int DEFAULT_STREAM_BUFFER_SIZE = 102400;
+
+    @Override
+    protected void doHead(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doRequest(request, response, true);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doRequest(request, response, false);
+    }
+
+    private void doRequest(HttpServletRequest request, HttpServletResponse response, boolean head) throws IOException {
+        response.reset();
+        StaticResource resource;
+
+        try {
+            resource = getStaticResource(request);
+        } catch (IllegalArgumentException e) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        if (resource == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        String fileName = URLEncoder.encode(resource.getFileName(), StandardCharsets.UTF_8.name());
+        boolean notModified = setCacheHeaders(request, response, fileName, resource.getLastModified());
+
+        if (notModified) {
+            response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+            return;
+        }
+
+        setContentHeaders(response, fileName, resource.getContentLength());
+
+        if (head) {
+            return;
+        }
+
+        writeContent(response, resource);
+    }
+
+    /**
+     * Returns the static resource associated with the given HTTP servlet request.
+     * This returns <code>null</code> when the resource does actually not exist. The
+     * servlet will then return a HTTP 404 error.
+     * 
+     * @param request
+     *            The involved HTTP servlet request.
+     * @return The static resource associated with the given HTTP servlet request.
+     * @throws IllegalArgumentException
+     *             When the request is mangled in such way that it's not
+     *             recognizable as a valid static resource request. The servlet will
+     *             then return a HTTP 400 error.
+     */
+    protected abstract StaticResource getStaticResource(HttpServletRequest request) throws IllegalArgumentException;
+
+    private boolean setCacheHeaders(HttpServletRequest request, HttpServletResponse response, String fileName,
+            long lastModified) {
+        String eTag = String.format(ETAG_HEADER, fileName, lastModified);
+        response.setHeader("ETag", eTag);
+        response.setDateHeader("Last-Modified", lastModified);
+        response.setDateHeader("Expires", System.currentTimeMillis() + DEFAULT_EXPIRE_TIME_IN_MILLIS);
+        return notModified(request, eTag, lastModified);
+    }
+
+    private boolean notModified(HttpServletRequest request, String eTag, long lastModified) {
+        String ifNoneMatch = request.getHeader("If-None-Match");
+
+        if (ifNoneMatch != null) {
+            String[] matches = ifNoneMatch.split("\\s*,\\s*");
+            Arrays.sort(matches);
+            return (Arrays.binarySearch(matches, eTag) > -1 || Arrays.binarySearch(matches, "*") > -1);
+        } else {
+            long ifModifiedSince = request.getDateHeader("If-Modified-Since");
+            return (ifModifiedSince + ONE_SECOND_IN_MILLIS > lastModified); // That second is because the header is in
+                                                                            // seconds, not millis.
+        }
+    }
+
+    private void setContentHeaders(HttpServletResponse response, String fileName, long contentLength) {
+        response.setHeader("Content-Type", getServletContext().getMimeType(fileName));
+        response.setHeader("Content-Disposition", String.format(CONTENT_DISPOSITION_HEADER, fileName));
+
+        if (contentLength != -1) {
+            response.setHeader("Content-Length", String.valueOf(contentLength));
+        }
+    }
+
+    private void writeContent(HttpServletResponse response, StaticResource resource) throws IOException {
+        try (ReadableByteChannel inputChannel = Channels.newChannel(resource.getInputStream());
+                WritableByteChannel outputChannel = Channels.newChannel(response.getOutputStream());) {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(DEFAULT_STREAM_BUFFER_SIZE);
+            long size = 0;
+
+            while (inputChannel.read(buffer) != -1) {
+                buffer.flip();
+                size += outputChannel.write(buffer);
+                buffer.clear();
+            }
+
+            if (resource.getContentLength() == -1 && !response.isCommitted()) {
+                response.setHeader("Content-Length", String.valueOf(size));
+            }
+        }
+    }
+
+}

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/AbstractStaticResourceServlet.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/AbstractStaticResourceServlet.java
@@ -70,6 +70,8 @@ public abstract class AbstractStaticResourceServlet extends HttpServlet {
             return;
         }
 
+        response.addHeader("Access-Control-Allow-Origin", "*");
+
         writeContent(response, resource);
     }
 

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/DataServlet.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/DataServlet.java
@@ -1,0 +1,81 @@
+package rosa.iiif.presentation.endpoint;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Serve out archive files.
+ */
+@Singleton
+public class DataServlet extends AbstractStaticResourceServlet {
+    private static final long serialVersionUID = 1L;
+    private Path data;
+
+    @Inject
+    public DataServlet() {
+        data = Util.getArchivePath(); 
+    }
+    
+    @Override
+    protected StaticResource getStaticResource(HttpServletRequest request) throws IllegalArgumentException{
+        String pathInfo = request.getPathInfo();
+
+        if (pathInfo == null || pathInfo.isEmpty() || "/".equals(pathInfo)) {
+            throw new IllegalArgumentException();
+        }
+
+        String name;
+        
+        try {
+            name = URLDecoder.decode(pathInfo.substring(1), StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        
+        Path resource = data.resolve(name).toAbsolutePath();
+        
+        // Prevent access to resource outside of the data path
+        if (!resource.startsWith(data)) {
+            return null;
+        }
+
+        if (!Files.exists(resource)) {
+            return null;
+        }
+        
+        File file = resource.toFile();
+        
+        return new StaticResource() {
+            @Override
+            public long getLastModified() {
+                return file.lastModified();
+            }
+            
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return Files.newInputStream(resource);
+            }
+            
+            @Override
+            public String getFileName() {
+                return file.getName();
+            }
+            
+            @Override
+            public long getContentLength() {
+                return file.length();
+            }
+        };
+    }
+}

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/IIIFPresentationServletModule.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/IIIFPresentationServletModule.java
@@ -26,6 +26,7 @@ import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.IIIFPresentationRequestParser;
 import rosa.iiif.presentation.core.IIIFPresentationService;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.core.jhsearch.JHSearchService;
 import rosa.iiif.presentation.core.jhsearch.LuceneJHSearchService;
 import rosa.iiif.presentation.core.transform.PresentationSerializer;
@@ -36,7 +37,7 @@ import rosa.iiif.presentation.core.transform.impl.PresentationTransformerImpl;
 /**
  * The servlet is configured by iiif-servlet.properties.
  */
-
+@SuppressWarnings("unused")
 public class IIIFPresentationServletModule extends ServletModule {
     private static final Logger LOG = Logger.getLogger(IIIFPresentationServletModule.class.toString());
 
@@ -74,7 +75,7 @@ public class IIIFPresentationServletModule extends ServletModule {
         ByteStreamGroup base = new FSByteStreamGroup(archive_path);
         return new StoreImpl(serializers, bookChecker, collectionChecker, base, false);
     }
-    
+
     @Provides
     IIIFPresentationCache provideIIIFPresentationCache(Store store) {
             return new IIIFPresentationCache(store, 5000);
@@ -85,7 +86,7 @@ public class IIIFPresentationServletModule extends ServletModule {
                                     PresentationTransformer transformer) {
         return new ArchiveIIIFPresentationService(cache, jsonld_serializer, transformer);
     }
-    
+
     @Provides
     IIIFPresentationRequestFormatter provideIIIFPresentationRequestFormatter(@Named("iiif.pres.scheme") String scheme,
                                                              @Named("iiif.pres.host") String host,
@@ -93,7 +94,6 @@ public class IIIFPresentationServletModule extends ServletModule {
                                                              @Named("iiif.pres.port") int port) {
         return new IIIFPresentationRequestFormatter(scheme, host, prefix, port);
     }
-    
 
     @Provides
     rosa.iiif.image.core.IIIFRequestFormatter provideImageRequestFormatter(@Named("iiif.image.scheme") String scheme,
@@ -102,12 +102,21 @@ public class IIIFPresentationServletModule extends ServletModule {
                                                                            @Named("iiif.image.port") int port) {
         return new rosa.iiif.image.core.IIIFRequestFormatter(scheme, host, port, prefix);
     }
-    
+
     @Provides
-    PresentationUris providePresentationUris(IIIFPresentationRequestFormatter presFormatter, IIIFRequestFormatter imageFormatter) {
-        return new PresentationUris(presFormatter, imageFormatter);
+    StaticResourceRequestFormatter provideStaticResourceRequestFormatter(@Named("iiif.pres.scheme") String scheme,
+                                                                         @Named("iiif.pres.host") String host,
+                                                                         @Named("static.prefix") String prefix,
+                                                                         @Named("iiif.pres.port") int port) {
+        return new StaticResourceRequestFormatter(scheme, host, prefix, port);
     }
-    
+
+    @Provides
+    PresentationUris providePresentationUris(IIIFPresentationRequestFormatter presFormatter, IIIFRequestFormatter imageFormatter,
+                                             StaticResourceRequestFormatter staticFormatter) {
+        return new PresentationUris(presFormatter, imageFormatter, staticFormatter);
+    }
+
     @Provides
     JHSearchService provideJHSearchService(PresentationUris pres_uris) {
         try {

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/StaticResource.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/StaticResource.java
@@ -1,0 +1,38 @@
+package rosa.iiif.presentation.endpoint;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+interface StaticResource {
+
+    /**
+     * Returns the file name of the resource. This must be unique across all static resources. If any, the file
+     * extension will be used to determine the content type being set. If the container doesn't recognize the
+     * extension, then you can always register it as <code>&lt;mime-type&gt;</code> in <code>web.xml</code>.
+     * @return The file name of the resource.
+     */
+    public String getFileName();
+
+    /**
+     * Returns the last modified timestamp of the resource in milliseconds.
+     * @return The last modified timestamp of the resource in milliseconds.
+     */
+    public long getLastModified();
+
+    /**
+     * Returns the content length of the resource. This returns <code>-1</code> if the content length is unknown.
+     * In that case, the container will automatically switch to chunked encoding if the response is already
+     * committed after streaming. The file download progress may be unknown.
+     * @return The content length of the resource.
+     */
+    public long getContentLength();
+
+    /**
+     * Returns the input stream with the content of the resource. This method will be called only once by the
+     * servlet, and only when the resource actually needs to be streamed, so lazy loading is not necessary.
+     * @return The input stream with the content of the resource.
+     * @throws IOException When something fails at I/O level.
+     */
+    public InputStream getInputStream() throws IOException;
+
+}

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/Util.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/java/rosa/iiif/presentation/endpoint/Util.java
@@ -1,0 +1,28 @@
+package rosa.iiif.presentation.endpoint;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Util {
+    public static final String SERVLET_CONFIG_PATH = "/iiif-servlet.properties";
+    private static final String LUCENE_DIRECTORY = "lucene";
+    private static final String ARCHIVE_DIRECTORY = "archive";
+    
+    // Derive the web app path from location of iiif-servlet.properties    
+    private static Path get_webapp_path() {
+        try {
+            return Paths.get(Util.class.getResource(SERVLET_CONFIG_PATH).toURI()).getParent().getParent();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Failed find webapp path", e);
+        }
+    }
+    
+    public static Path getArchivePath() {
+        return get_webapp_path().resolve(ARCHIVE_DIRECTORY);
+    }
+    
+    public static Path getLucenePath() {
+        return get_webapp_path().resolve(LUCENE_DIRECTORY);
+    }
+}

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/resources/iiif-servlet.properties
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/main/resources/iiif-servlet.properties
@@ -13,3 +13,9 @@ iiif.image.host = ${iiif.image.host}
 iiif.image.port = ${iiif.image.port}
 iiif.image.prefix = ${iiif.image.prefix}
 
+# Location of static resource servlet
+
+static.scheme = ${iiif.pres.scheme}
+static.host = ${iiif.pres.host}
+static.port = ${iiif.pres.port}
+static.prefix = ${iiif.pres.prefix}/data

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/java/rosa/iiif/presentation/endpoint/IIIFPresentationServletConfigTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/java/rosa/iiif/presentation/endpoint/IIIFPresentationServletConfigTest.java
@@ -15,6 +15,7 @@ import com.google.inject.Injector;
 
 import rosa.iiif.presentation.core.IIIFPresentationService;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.core.transform.impl.PresentationTransformerImpl;
 
 public class IIIFPresentationServletConfigTest {
@@ -27,7 +28,11 @@ public class IIIFPresentationServletConfigTest {
             + "iiif.image.scheme = http\n"
             + "iiif.image.host = rosetest.library.jhu.edu\n" 
             + "iiif.image.port = 80\n"
-            + "iiif.image.prefix = /iiifimage\n";
+            + "iiif.image.prefix = /iiifimage\n"
+            + "static.scheme = http\n"
+            + "static.host = rosetest.library.jhu.edu\n"
+            + "static.port = 80\n"
+            + "static.prefix = /iiifpres/data\n";
 
     /**
      * Must write new 'iiifservlet.properties' with valid values because it has not been
@@ -68,5 +73,8 @@ public class IIIFPresentationServletConfigTest {
 
         IIIFPresentationServlet servlet = injector.getInstance(IIIFPresentationServlet.class);
         assertNotNull("Failed to inject IIIF Servlet.", servlet);
+
+        StaticResourceRequestFormatter staticFormatter = injector.getInstance(StaticResourceRequestFormatter.class);
+        assertNotNull("Failed to inject Static Resource Request Formatter", staticFormatter);
     }
 }

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/java/rosa/iiif/presentation/endpoint/IIIFPresentationServletITModule.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/java/rosa/iiif/presentation/endpoint/IIIFPresentationServletITModule.java
@@ -13,6 +13,7 @@ import rosa.archive.core.check.BookCollectionChecker;
 import rosa.archive.core.serialize.SerializerSet;
 import rosa.iiif.image.core.IIIFRequestFormatter;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 
 
 /**
@@ -39,5 +40,10 @@ public class IIIFPresentationServletITModule extends AbstractModule {
     @Provides
     IIIFRequestFormatter provideIIIFRequestFormatter() {
         return new IIIFRequestFormatter("http", "localhost", 9090, "/iiif-image");
+    }
+
+    @Provides
+    StaticResourceRequestFormatter provideStaticResourceRequestFormatter() {
+        return new StaticResourceRequestFormatter("http", "localhost", "/iiif-pres/data", 9090);
     }
 }

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/java/rosa/iiif/presentation/endpoint/ITIIIFPresentationServlet.java
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/java/rosa/iiif/presentation/endpoint/ITIIIFPresentationServlet.java
@@ -23,6 +23,7 @@ import rosa.archive.core.Store;
 import rosa.iiif.image.core.IIIFRequestFormatter;
 import rosa.iiif.presentation.core.IIIFPresentationRequestFormatter;
 import rosa.iiif.presentation.core.PresentationUris;
+import rosa.iiif.presentation.core.StaticResourceRequestFormatter;
 import rosa.iiif.presentation.core.jhsearch.JHSearchService;
 
 /**
@@ -37,7 +38,8 @@ public class ITIIIFPresentationServlet {
         Injector injector = Guice.createInjector(new ArchiveCoreModule(), new IIIFPresentationServletITModule());
 
         store = injector.getInstance(Store.class);
-        pres_uris = new PresentationUris(injector.getInstance(IIIFPresentationRequestFormatter.class), injector.getInstance(IIIFRequestFormatter.class));
+        pres_uris = new PresentationUris(injector.getInstance(IIIFPresentationRequestFormatter.class),
+                injector.getInstance(IIIFRequestFormatter.class), injector.getInstance(StaticResourceRequestFormatter.class));
     }
 
     private void check_json_syntax(InputStream is) throws Exception {
@@ -138,6 +140,50 @@ public class ITIIIFPresentationServlet {
             }
         }
     }
-    
+
+    /**
+     * Check any object's "related" property. If it exists, see if the URI is resolvable.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testResolveRelatedUris() throws Exception {
+        for (String col : store.listBookCollections()) {
+//            test_related_uris(pres_uris.getCollectionURI(col));
+            for (String book : store.listBooks(col)) {
+                test_related_uris(pres_uris.getManifestURI(col, book));
+            }
+        }
+    }
+
+    private void test_related_uris(String uri) throws Exception {
+        HttpURLConnection con = (HttpURLConnection) (new URL(uri)).openConnection();
+
+        con.connect();
+        int code = con.getResponseCode();
+        assertEquals(200, code);
+
+        try (InputStream is = con.getInputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
+            JsonNode base = objectMapper.readTree(is);
+
+            if (base.has("related")) {
+                String resourceUri = base.get("related").get("@id").textValue();
+                assertNotNull("A 'related' resource was found that had no access URI", resourceUri);
+
+                resolve_resource_uri(resourceUri);
+            }
+        }
+    }
+
+    private void resolve_resource_uri(String uri) throws Exception {
+        HttpURLConnection con = (HttpURLConnection) (new URL(uri)).openConnection();
+
+        con.connect();
+        int code = con.getResponseCode();
+        assertEquals(200, code);
+
+    }
     
 }

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/resources/iiif-servlet.properties
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/src/test/resources/iiif-servlet.properties
@@ -4,6 +4,7 @@ iiif.pres.scheme = ${iiif.pres.scheme}
 iiif.pres.host = ${iiif.pres.host}
 iiif.pres.port = ${iiif.pres.port}
 iiif.pres.prefix = ${iiif.pres.prefix}
+iiif.pres.max_cache_age = ${iiif.pres.max_cache_age}
 
 # Location of IIIF Image API implementation
 
@@ -12,3 +13,9 @@ iiif.image.host = ${iiif.image.host}
 iiif.image.port = ${iiif.image.port}
 iiif.image.prefix = ${iiif.image.prefix}
 
+# Location of static resource servlet
+
+static.scheme = ${iiif.pres.scheme}
+static.host = ${iiif.pres.host}
+static.port = ${iiif.pres.port}
+static.prefix = ${iiif.pres.prefix}/data


### PR DESCRIPTION
The presentation endpoint should now serve out files in WEB-INF/archive through /data.

This is untested and needs tests added.
Also directory listing will not work which is annoying.

Another way to do this would be to just rip out guice and move the archive directory out of WEB-INF.
