### PR TITLE
Fix issue causing search queries to always return zero results. Fix bug with ITs

### DIFF
--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/jhsearch/LuceneJHSearchService.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/jhsearch/LuceneJHSearchService.java
@@ -108,9 +108,9 @@ public class LuceneJHSearchService extends LuceneSearchService implements JHSear
         }
     
     /**
-     * @param path
-     * @param formatter
-     * @throws IOException
+     * @param path .
+     * @param pres_uris .
+     * @throws IOException .
      */
     public LuceneJHSearchService(Path path, PresentationUris pres_uris) throws IOException {
         super(path, new JHSearchLuceneMapper(pres_uris));
@@ -172,7 +172,7 @@ public class LuceneJHSearchService extends LuceneSearchService implements JHSear
                         new Query(JHSearchField.COLLECTION_ID, pizan_url)
                 );
             } else if (!"top".equals(name)) {
-                restrict_query = new Query(JHSearchField.COLLECTION_ID, pres_uris.getCollectionURI("name"));
+                restrict_query = new Query(JHSearchField.COLLECTION_ID, pres_uris.getCollectionURI(name));
             }
         } else if (req.getType() == PresentationRequestType.MANIFEST) {
             restrict_query = new Query(JHSearchField.MANIFEST_ID, pres_uris.getManifestURI(req.getIdentifier()[0], req.getIdentifier()[1]));


### PR DESCRIPTION
* Previously, all searches would return 0 results
* Remove a test that was introduced that tested for the presence of a manifest's _related_ property, and tried to resolve the URI if found. This test was actually incorrect, as these URIs are determined by the System properties at build time, making these URIs not relevant in the IT context. Say you start a build targeting `test.example.com`. The IT will scan manifests on `localhost:9090`, but the _related_ URIs all point to `test.example.com`, which will not resolve, and the test will fail.
  * This test passes in Travis because the build is done against an empty archive