### PR TITLE
Don't linkify references with more than one target in transcription

### DIFF
--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/html/AnnotationBaseHtmlAdapter.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/html/AnnotationBaseHtmlAdapter.java
@@ -292,6 +292,11 @@ public abstract class AnnotationBaseHtmlAdapter<T> implements AnnotationConstant
         }
 
         for (InternalReference ref : refs) {
+            // TODO temp block preventing decoration of references with more than 1 target to avoid user confusion
+            if (ref.getTargets().size() > 1) {
+                continue;
+            }
+
             boolean textInRef = ref.getText() != null && !ref.getText().isEmpty();
 
             for (ReferenceTarget target : ref.getTargets()) {

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/html/MarginaliaHtmlAdapterTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/html/MarginaliaHtmlAdapterTest.java
@@ -123,7 +123,8 @@ public class MarginaliaHtmlAdapterTest {
 
         String result = adapter.addInternalRefs(fakeCollection, transcription, Collections.singletonList(ref));
 
-        assertEquals(expected, result);
+//        assertEquals(expected, result);
+        assertEquals(transcription, result);
     }
 
     @Test
@@ -220,7 +221,8 @@ public class MarginaliaHtmlAdapterTest {
                 ">test</a> moo";
 
         String result = adapter.addInternalRefs(fakeCollection, transcription, Collections.singletonList(doubleTargetRef()));
-        assertEquals(expected, result);
+//        assertEquals(expected, result);
+        assertEquals(transcription, result);
     }
 
     private InternalReference newRef() {
@@ -320,6 +322,7 @@ public class MarginaliaHtmlAdapterTest {
         InternalReference r1 = new InternalReference("s[upr]a", t1);
 
         String result = adapter.addInternalRefs(fakeCollection, transcription, Collections.singletonList(r1));
-        assertEquals(expected, result);
+//        assertEquals(expected, result);
+        assertEquals(transcription, result);
     }
 }


### PR DESCRIPTION
Prior behavior was to convert internal references into clickable links inline in the transcription text. This PR prevents this when the internal reference has more than one target. This is done because the viewer is unable to differentiate and will navigate to only the first target without telling the user about the other targets. 