### PR TITLE
Prevent copy tool from skipping over permissions statement files

### DIFF
--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/FSByteStreamGroup.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/FSByteStreamGroup.java
@@ -26,7 +26,7 @@ public class FSByteStreamGroup implements ByteStreamGroup {
     /**
      * Extensions of files to copy when copying metadata
      */
-    private static String[] METADATA_COPY_FILE_EXT = {"xml", "csv", "txt", "properties"};
+    private static String[] METADATA_COPY_FILE_EXT = {"xml", "csv", "txt", "properties", "html"};
     
     private Path base;
 

--- a/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/transform/JsonldSerializerTest.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/test/java/rosa/iiif/presentation/core/transform/JsonldSerializerTest.java
@@ -1,9 +1,5 @@
 package rosa.iiif.presentation.core.transform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +30,8 @@ import rosa.iiif.presentation.model.Within;
 import rosa.iiif.presentation.model.annotation.Annotation;
 import rosa.iiif.presentation.model.annotation.AnnotationSource;
 import rosa.iiif.presentation.model.annotation.AnnotationTarget;
+
+import static org.junit.Assert.*;
 
 public class JsonldSerializerTest {
     private static final String IIIF_CONTEXT_URL = "http://iiif.io/api/presentation/2/context.json";
@@ -71,6 +69,8 @@ public class JsonldSerializerTest {
         assertFalse("JSON-LD string is empty.", json.isEmpty());
 
         checkForIIIFContextAppearances(json, 1);
+
+        assertTrue("No attribution (permission) found", json.contains("This is the attribution"));
     }
 
     @Test


### PR DESCRIPTION
Fix a bug that caused the permission files from being copied into the IIIF presentation webapp. This caused the permission statements from absent from the IIIF manifests.