### PR TITLE
Add simple Web Annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This project provides tools to manage archives of data and services to provide a
 
 # Building
 
-See the build scripts. The archive specified as archive.path must contain collections either named aor, rose, pizan, or top in order to support search.
+Java 8 is required. Integration tests will fail on Java 11.
 
+See the build scripts. The archive specified as archive.path must contain collections either named aor, rose, pizan, or top in order to support search.
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,5 @@ This project provides tools to manage archives of data and services to provide a
 
 Java 8 is required. Integration tests will fail on Java 11.
 
-See the build scripts. The archive specified as archive.path must contain collections either named aor, rose, pizan, or top in order to support search.
-
-
-
+See the build scripts. The archive specified as archive.path must contain collections either named aor, rose, pizan, or dlmm in order to support search.
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>rosa</groupId>
     <artifactId>rosa-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <scm>
         <connection>scm:git:https://github.com/jhu-digital-manuscripts/rosa2.git</connection>

--- a/rosa-archive/pom.xml
+++ b/rosa-archive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rosa-parent</artifactId>
         <groupId>rosa</groupId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>    

--- a/rosa-archive/rosa-archive-aor-tool/pom.xml
+++ b/rosa-archive/rosa-archive-aor-tool/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>rosa-archive-parent</artifactId>
     <groupId>rosa.archive</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-archive/rosa-archive-core/pom.xml
+++ b/rosa-archive/rosa-archive-core/pom.xml
@@ -80,6 +80,11 @@
           <artifactId>imageio-tiff</artifactId>
 	</dependency>
 
+	<dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
        <!-- Test dependencies -->
 
        <dependency>

--- a/rosa-archive/rosa-archive-core/pom.xml
+++ b/rosa-archive/rosa-archive-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rosa-archive-parent</artifactId>
         <groupId>rosa.archive</groupId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/ArchiveConstants.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/ArchiveConstants.java
@@ -87,6 +87,8 @@ public interface ArchiveConstants {
     String LOCATIONS = "locations.csv";
 
     String BOOKS = "books.csv";
+    
+    String HTML_ANNOS = "annos.jsonld";
 
     String ID_LOCATION_MAP = "id_locations.csv";
 

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/ArchiveCoreModule.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/ArchiveCoreModule.java
@@ -10,6 +10,7 @@ import rosa.archive.core.serialize.BookStructureSerializer;
 import rosa.archive.core.serialize.CharacterNamesSerializer;
 import rosa.archive.core.serialize.CropInfoSerializer;
 import rosa.archive.core.serialize.FileMapSerializer;
+import rosa.archive.core.serialize.HTMLAnnotationsSerializer;
 import rosa.archive.core.serialize.IllustrationTaggingSerializer;
 import rosa.archive.core.serialize.IllustrationTitlesSerializer;
 import rosa.archive.core.serialize.ImageListSerializer;
@@ -54,6 +55,7 @@ public class ArchiveCoreModule extends AbstractModule {
         serializers.addBinding().to(BookReferenceSheetSerializer.class);
         serializers.addBinding().to(FileMapSerializer.class);
         serializers.addBinding().to(BookDescriptionSerializer.class);
+        serializers.addBinding().to(HTMLAnnotationsSerializer.class);
         
         bind(SerializerSet.class);
         

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/FSByteStreamGroup.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/FSByteStreamGroup.java
@@ -26,7 +26,7 @@ public class FSByteStreamGroup implements ByteStreamGroup {
     /**
      * Extensions of files to copy when copying metadata
      */
-    private static String[] METADATA_COPY_FILE_EXT = {"xml", "csv", "txt", "properties", "html"};
+    private static String[] METADATA_COPY_FILE_EXT = {"xml", "csv", "txt", "properties", "html", "jsonld"};
     
     private Path base;
 

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/StoreImpl.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/StoreImpl.java
@@ -52,6 +52,7 @@ import rosa.archive.model.CollectionMetadata;
 import rosa.archive.model.CropData;
 import rosa.archive.model.CropInfo;
 import rosa.archive.model.FileMap;
+import rosa.archive.model.HTMLAnnotations;
 import rosa.archive.model.HasId;
 import rosa.archive.model.HashAlgorithm;
 import rosa.archive.model.IllustrationTagging;
@@ -151,6 +152,7 @@ public class StoreImpl implements Store, ArchiveConstants {
         collection.setPeopleRef(loadItem(PEOPLE, collectionGroup, ReferenceSheet.class, errors));
         collection.setLocationsRef(loadItem(LOCATIONS, collectionGroup, ReferenceSheet.class, errors));
         collection.setBooksRef(loadItem(BOOKS, collectionGroup, BookReferenceSheet.class, errors));
+        collection.setHTMLAnnotations(loadItem(HTML_ANNOS, collectionGroup, HTMLAnnotations.class, errors));
 
         Properties props = new Properties();
         try (InputStream configIn = collectionGroup.getByteStream(COLLECTION_CONFIG)) {

--- a/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/HTMLAnnotationsSerializer.java
+++ b/rosa-archive/rosa-archive-core/src/main/java/rosa/archive/core/serialize/HTMLAnnotationsSerializer.java
@@ -1,0 +1,100 @@
+package rosa.archive.core.serialize;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import rosa.archive.core.ArchiveConstants;
+import rosa.archive.model.HTMLAnnotations;
+
+/**
+ * Use Web Annotation JSON-LD as the serialization format.
+ * Assume it is JSON array of Web Annotation objects which look like:
+ * <pre>
+ * {
+ * "@context": "http://www.w3.org/ns/anno.jsonld",
+ * "id": "http://example.org/anno5",
+ * "type": "Annotation",
+ * "via" : "http://example.com/blah.html",
+ * "body": {
+ *   "type" : "TextualBody",
+ *   "value" : "<p>Moo!</p>",
+ *   "format" : "text/html",
+ * },
+ * "target": "rosa:ARCHIVE_ID"
+ * }
+ * </pre>
+ * 
+ * The target uri must use the rosa schema and have a path which is the archive id.
+ * The via statement can be used to indicate where this annotation was obtained.
+ */
+public class HTMLAnnotationsSerializer implements Serializer<HTMLAnnotations>, ArchiveConstants {
+	private static final String ARCHIVE_URI_SCHEME = "rosa";
+	
+    @Override
+    public HTMLAnnotations read(InputStream is, List<String> errors) throws IOException {
+       HTMLAnnotations result = new HTMLAnnotations();
+       
+       JSONArray array = new JSONArray(new JSONTokener(is));
+
+       for (int i = 0; i < array.length(); i++) {
+    	   JSONObject obj = array.getJSONObject(i);
+    	   
+    	   String context = obj.getString("@context");
+    	   String type = obj.getString("type");
+    	   String id = obj.getString("id");
+    	   String target = obj.getString("target");
+    	   
+    	   JSONObject body_obj = obj.getJSONObject("body");
+    	   
+    	   if (context == null || !context.equals("http://www.w3.org/ns/anno.jsonld")) {
+    		   throw new IOException("Web Annotation has invalid context: " + obj);
+    	   }
+    	   
+    	   if (type == null || !type.equals("Annotation")) {
+    		   throw new IOException("Web Annotation has invalid type: " + obj);
+    	   }
+    	   
+    	   String body_type = body_obj.getString("type");
+    	   String body_value = body_obj.getString("value");
+    	   String body_format = body_obj.getString("format");
+
+    	   if (body_type == null || !body_type.equals("TextualBody")) {
+    		   throw new IOException("Web Annotation body has unsupported type: " + obj);
+    	   }
+    	   
+    	   if (body_format == null || !body_format.equals("text/html")) {
+    		   throw new IOException("Web Annotation body has unsupported format: " + obj);
+    	   }
+    	   
+    	   if (body_value== null) {
+    		   throw new IOException("Web Annotation body missing value: " + obj);
+    	   }
+    	   
+    	   if (!target.startsWith(ARCHIVE_URI_SCHEME)) {
+    		   throw new IOException("Unsupported Web Annotation target: " + obj);
+    	   }
+    	   
+    	   String archive_id = target.substring(ARCHIVE_URI_SCHEME.length() + 1);
+
+    	   result.setAnnotation(archive_id, body_value);
+       }
+       
+       return result;
+    }
+
+    @Override
+    public void write(HTMLAnnotations map, OutputStream out) throws IOException {
+    	throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Class<HTMLAnnotations> getObjectType() {
+        return HTMLAnnotations.class;
+    }
+}

--- a/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/BaseSearchTest.java
+++ b/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/BaseSearchTest.java
@@ -15,6 +15,7 @@ import rosa.archive.core.serialize.BookStructureSerializer;
 import rosa.archive.core.serialize.CharacterNamesSerializer;
 import rosa.archive.core.serialize.CropInfoSerializer;
 import rosa.archive.core.serialize.FileMapSerializer;
+import rosa.archive.core.serialize.HTMLAnnotationsSerializer;
 import rosa.archive.core.serialize.IllustrationTaggingSerializer;
 import rosa.archive.core.serialize.IllustrationTitlesSerializer;
 import rosa.archive.core.serialize.ImageListSerializer;
@@ -90,6 +91,7 @@ public abstract class BaseSearchTest {
                 new ReferenceSheetSerializer(),
                 new BookReferenceSheetSerializer(),
                 new FileMapSerializer(),
+                new HTMLAnnotationsSerializer(),
                 new BookDescriptionSerializer()
         )));
 

--- a/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/FSByteStreamGroupTest.java
+++ b/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/FSByteStreamGroupTest.java
@@ -87,7 +87,7 @@ public class FSByteStreamGroupTest extends BaseArchiveTest {
     public void dataFolderHasSixByteStreams() throws IOException {
         ByteStreamGroup data = base.getByteStreamGroup("valid");
         assertNotNull(data);
-        assertEquals(9, data.numberOfByteStreams());
+        assertEquals(10, data.numberOfByteStreams());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class FSByteStreamGroupTest extends BaseArchiveTest {
 
         List<String> ids = data.listByteStreamIds();
         assertNotNull(ids);
-        assertEquals(9, ids.size());
+        assertEquals(10, ids.size());
     }
 
     @Test

--- a/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/serialize/HtmlAnnotationsSerializerTest.java
+++ b/rosa-archive/rosa-archive-core/src/test/java/rosa/archive/core/serialize/HtmlAnnotationsSerializerTest.java
@@ -1,0 +1,27 @@
+package rosa.archive.core.serialize;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import rosa.archive.model.HTMLAnnotations;
+
+public class HtmlAnnotationsSerializerTest {
+	@Test
+	public void testSerializerLoad() throws IOException {
+		HTMLAnnotationsSerializer serializer = new HTMLAnnotationsSerializer();
+		
+		try (InputStream is = getClass().getResourceAsStream("/archive/valid/annos.jsonld")) {
+			HTMLAnnotations annos = serializer.read(is, null);
+			
+			assertEquals(1, annos.size());
+			
+			String anno = annos.getAnnotation("LudwigXV7.003r.tif");
+			
+			assertEquals("<div>Here is an annotation</div>", anno);
+		}
+	}
+}

--- a/rosa-archive/rosa-archive-core/src/test/resources/archive/valid/annos.jsonld
+++ b/rosa-archive/rosa-archive-core/src/test/resources/archive/valid/annos.jsonld
@@ -1,0 +1,14 @@
+[
+    {
+        "id": "rosa:annos.jsonld#0",
+        "type": "Annotation",
+        "body": {
+            "format": "text/html",
+            "type": "TextualBody",
+            "value": "<div>Here is an annotation</div>"
+        },
+        "@context": "http://www.w3.org/ns/anno.jsonld",
+        "via": "http://example.com/blah.html",
+        "target": "rosa:LudwigXV7.003r.tif"
+    }
+]

--- a/rosa-archive/rosa-archive-core/src/test/resources/archive/valid/valid.SHA1SUM
+++ b/rosa-archive/rosa-archive-core/src/test/resources/archive/valid/valid.SHA1SUM
@@ -6,3 +6,4 @@ d138f84b449dc22b57142dad5e5fb6bf0b61bced  locations.csv
 b6675108cc0b991dd29deab06a35256b8f7cafc0  missing_image.tif
 ee9f1eea6894bb9fd6b88e61aaaf61653f8e9df8  character_names.csv
 440859759c7f92855c2c40843673bee71e273758  illustration_titles.csv
+eb3e53e828364d103fab1448d8b98205d367a9f7  annos.jsonld

--- a/rosa-archive/rosa-archive-model/pom.xml
+++ b/rosa-archive/rosa-archive-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rosa-archive-parent</artifactId>
         <groupId>rosa.archive</groupId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/BookCollection.java
+++ b/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/BookCollection.java
@@ -23,6 +23,7 @@ public class BookCollection implements HasId, Serializable {
     private NarrativeSections narrativeSections;
     private SHA1Checksum checksums;
     private BookImage missingImage;
+    private HTMLAnnotations htmlAnnos;
 
     private ReferenceSheet peopleRef;
     private ReferenceSheet locationsRef;
@@ -112,6 +113,14 @@ public class BookCollection implements HasId, Serializable {
 
     public void setNarrativeSections(NarrativeSections narrativeSections) {
         this.narrativeSections = narrativeSections;
+    }
+
+    public HTMLAnnotations getHTMLAnnotations() {
+    	return htmlAnnos;
+    }
+    
+    public void setHTMLAnnotations(HTMLAnnotations annos) {
+    	this.htmlAnnos = annos;
     }
 
     /**
@@ -205,12 +214,13 @@ public class BookCollection implements HasId, Serializable {
                 Objects.equals(locationsRef, that.locationsRef) &&
                 Objects.equals(booksRef, that.booksRef) &&
                 Objects.equals(metadata, that.metadata) &&
-                Objects.equals(annotationMap, that.annotationMap);
+                Objects.equals(annotationMap, that.annotationMap) &&
+                Objects.equals(htmlAnnos, that.htmlAnnos);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(id, characterNames, illustrationTitles, narrativeSections, checksums, missingImage, peopleRef, locationsRef, booksRef, metadata, annotationMap);
+        int result = Objects.hash(id, characterNames, illustrationTitles, narrativeSections, checksums, missingImage, peopleRef, locationsRef, booksRef, metadata, annotationMap, htmlAnnos);
         result = 31 * result + Arrays.hashCode(books);
         return result;
     }

--- a/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/HTMLAnnotations.java
+++ b/rosa-archive/rosa-archive-model/src/main/java/rosa/archive/model/HTMLAnnotations.java
@@ -1,0 +1,75 @@
+package rosa.archive.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A set of HTML annotations that target books, images, or collections.
+ * The HTML should be a simple and able to be embedded in an existing HTML document easily.
+ */
+public class HTMLAnnotations implements HasId {
+	private final Map<String, String> annotations;
+	private String id;
+	
+	public HTMLAnnotations() {
+		this.annotations = new HashMap<String, String>();
+	}
+	
+	public void setAnnotation(String target_id, String html) {
+		annotations.put(target_id, html);
+	}
+	
+	/**
+	 * @param target_id
+	 * @return HTML annotation with given target.
+	 */
+	public String getAnnotation(String target_id) {
+		return annotations.get(target_id);
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+
+	@Override
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((annotations == null) ? 0 : annotations.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HTMLAnnotations other = (HTMLAnnotations) obj;
+		if (annotations == null) {
+			if (other.annotations != null)
+				return false;
+		} else if (!annotations.equals(other.annotations))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+
+	public int size() {
+		return annotations.size();
+	}
+}

--- a/rosa-archive/rosa-archive-model/src/test/java/rosa/archive/model/ModelEqualsAndHashCodeTest.java
+++ b/rosa-archive/rosa-archive-model/src/test/java/rosa/archive/model/ModelEqualsAndHashCodeTest.java
@@ -248,4 +248,13 @@ public class ModelEqualsAndHashCodeTest {
                 .verify();
     }
 
+    @Test
+    public void htmlAnnotationsTest() {
+        EqualsVerifier
+                .forClass(HTMLAnnotations.class)
+                .usingGetClass()
+                .allFieldsShouldBeUsed()
+                .suppress(Warning.STRICT_INHERITANCE, Warning.NONFINAL_FIELDS)
+                .verify();
+    }
 }

--- a/rosa-archive/rosa-archive-tool/pom.xml
+++ b/rosa-archive/rosa-archive-tool/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rosa-archive-parent</artifactId>
         <groupId>rosa.archive</groupId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rosa-iiif/pom.xml
+++ b/rosa-iiif/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>rosa-parent</artifactId>
     <groupId>rosa</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-image-core/pom.xml
+++ b/rosa-iiif/rosa-iiif-image-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>rosa-iiif-parent</artifactId>
     <groupId>rosa.iiif</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-image-endpoint/pom.xml
+++ b/rosa-iiif/rosa-iiif-image-endpoint/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>rosa-iiif-parent</artifactId>
     <groupId>rosa.iiif</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-image-model/pom.xml
+++ b/rosa-iiif/rosa-iiif-image-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>rosa-iiif-parent</artifactId>
     <groupId>rosa.iiif</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-presentation-core/pom.xml
+++ b/rosa-iiif/rosa-iiif-presentation-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>rosa.iiif</groupId>
         <artifactId>rosa-iiif-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/jhsearch/JHSearchLuceneMapper.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/jhsearch/JHSearchLuceneMapper.java
@@ -28,6 +28,7 @@ import rosa.archive.model.BookImage;
 import rosa.archive.model.BookMetadata;
 import rosa.archive.model.BookText;
 import rosa.archive.model.CharacterNames;
+import rosa.archive.model.HTMLAnnotations;
 import rosa.archive.model.Illustration;
 import rosa.archive.model.IllustrationTagging;
 import rosa.archive.model.IllustrationTitles;
@@ -243,9 +244,10 @@ public class JHSearchLuceneMapper extends BaseLuceneMapper {
 		}
 
 		IllustrationTagging tag = book.getIllustrationTagging();
-
+		HTMLAnnotations annos = col.getHTMLAnnotations();
+		
 		if (tag != null) {
-			index(col, book, image, doc, tag);
+			index(col, book, image, doc, tag, annos);
 		}
 
 		// Index transcription text that appears on this page
@@ -259,7 +261,7 @@ public class JHSearchLuceneMapper extends BaseLuceneMapper {
 
 	}
 
-	private void index(BookCollection col, Book book, BookImage image, Document doc, IllustrationTagging imgtag) {
+	private void index(BookCollection col, Book book, BookImage image, Document doc, IllustrationTagging imgtag, HTMLAnnotations annos) {
 		IllustrationTitles titles = col.getIllustrationTitles();
 		CharacterNames char_names = col.getCharacterNames();
 
@@ -309,6 +311,17 @@ public class JHSearchLuceneMapper extends BaseLuceneMapper {
 			text.append(", ");
 		}
 
+		if (annos != null) {
+			// TODO: Assume the HTML annos are about illustrations
+		
+			String htmlanno = annos.getAnnotation(image.getId());
+		
+			if (htmlanno != null) {
+				// TODO Hack to remove elements
+				text.append(htmlanno.replaceAll("\\<.*?\\>", " "));
+			}
+		}
+		
 		if (text.length() > 0) {
 			addField(doc, JHSearchField.ILLUSTRATION, SearchFieldType.ENGLISH, text.toString());
 		}

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/AnnotationListTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/AnnotationListTransformer.java
@@ -96,6 +96,14 @@ public class AnnotationListTransformer implements TransformerConstants {
 
             annotations.addAll(anns);
             return list;
+        } else if (listType == AnnotationListType.HTML_ANNOS) {
+            List<Annotation> anns = annotationTransformer.htmlAnnotationsForPage(collection, book, image);
+            if (anns == null || anns.isEmpty()) {
+                return null;
+            }
+
+            annotations.addAll(anns);
+            return list;        	
         }
 
         // Annotated page can be NULL if no transcriptions are present.

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/AnnotationTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/AnnotationTransformer.java
@@ -23,6 +23,7 @@ import rosa.archive.model.BookCollection;
 import rosa.archive.model.BookImage;
 import rosa.archive.model.BookReferenceSheet;
 import rosa.archive.model.CharacterNames;
+import rosa.archive.model.HTMLAnnotations;
 import rosa.archive.model.Illustration;
 import rosa.archive.model.IllustrationTitles;
 import rosa.archive.model.aor.Calculation;
@@ -430,5 +431,31 @@ public class AnnotationTransformer implements TransformerConstants, AORAnnotated
     private boolean isNotEmpty(String str) {
         return str != null && !str.isEmpty();
     }
+
+	public List<Annotation> htmlAnnotationsForPage(BookCollection col, Book book, BookImage image) {
+		HTMLAnnotations annos = col.getHTMLAnnotations();
+		
+		if (annos == null) {
+			return null;
+		}
+		
+		String content = annos.getAnnotation(image.getId());
+		
+		if (content == null) {
+			return null;
+		}
+		
+        Annotation ann = new Annotation();
+        ann.setLabel("Annotation on " + image.getName(), "en");
+        ann.setId(pres_uris.getAnnotationURI(col.getId(), book.getId(), image, "htmlanno1"));
+        ann.setMotivation(OA_COMMENTING);
+        ann.setType(OA_ANNOTATION);
+        ann.setDefaultSource(new AnnotationSource(null, IIIFNames.DC_TEXT, "text/html", content, "en"));
+        ann.setDefaultTarget(locationOnCanvas(image, Location.INTEXT));
+        
+        List<Annotation> result = new ArrayList<>();
+        result.add(ann);
+        return result;
+	}
 
 }

--- a/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/CollectionTransformer.java
+++ b/rosa-iiif/rosa-iiif-presentation-core/src/main/java/rosa/iiif/presentation/core/transform/impl/CollectionTransformer.java
@@ -90,7 +90,7 @@ public class CollectionTransformer implements TransformerConstants {
             // Add references and search services for parent collections
             String parentURI = pres_uris.getCollectionURI(parentCol.getId());
             parents.add(new Within(parentURI, SC_COLLECTION, parentCol.getLabel()));
-            col.addService(new Service( JHSearchService.CONTEXT_URI, parentURI, IIIF_SEARCH_PROFILE, parentCol.getLabel()));
+            col.addService(new Service( JHSearchService.CONTEXT_URI, parentURI + JHSearchService.RESOURCE_PATH, IIIF_SEARCH_PROFILE, parentCol.getLabel()));
         }
         col.setWithin(parents.toArray(new Within[0]));
 

--- a/rosa-iiif/rosa-iiif-presentation-endpoint/pom.xml
+++ b/rosa-iiif/rosa-iiif-presentation-endpoint/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>rosa-iiif-parent</artifactId>
         <groupId>rosa.iiif</groupId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-presentation-model/pom.xml
+++ b/rosa-iiif/rosa-iiif-presentation-model/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>rosa.iiif</groupId>
         <artifactId>rosa-iiif-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rosa-iiif/rosa-iiif-presentation-model/src/main/java/rosa/iiif/presentation/model/AnnotationListType.java
+++ b/rosa-iiif/rosa-iiif-presentation-model/src/main/java/rosa/iiif/presentation/model/AnnotationListType.java
@@ -2,6 +2,7 @@ package rosa.iiif.presentation.model;
 
 public enum AnnotationListType {
     ALL,
+    HTML_ANNOS,
 
     // Rose specific
     ILLUSTRATION,

--- a/rosa-search/pom.xml
+++ b/rosa-search/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>rosa-parent</artifactId>
     <groupId>rosa</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-search/rosa-search-core/pom.xml
+++ b/rosa-search/rosa-search-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>rosa-search</artifactId>
     <groupId>rosa.search</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/rosa-search/rosa-search-model/pom.xml
+++ b/rosa-search/rosa-search-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>rosa-search</artifactId>
     <groupId>rosa.search</groupId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
- Simple Web Annotation support added
- Web Annotations must have included HTML body
- Web Annotations are serialized as an array in a Book Collection as annos.jsonld
- For the moment they are  indexed as illustration descriptions
- Web Annotations created by screen scraping MARGOT website, https://github.com/jhu-digital-manuscripts/margotanno
- All annotations actually target rose manuscripts and can be seen on rosetest DLMM site, for esxample Francias12595 52v.

Closes: #453 